### PR TITLE
add integration tests.

### DIFF
--- a/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-role-binding.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-role-binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.integrationTests.install }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.integrationTests.name }}-cluster-role-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.integrationTests.name }}-service-account
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.integrationTests.name }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-role.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-role.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.integrationTests.install }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.integrationTests.name }}-cluster-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get"]
+{{- end }}

--- a/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-service-account.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/integration-test-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.integrationTests.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.integrationTests.name }}-service-account
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/job.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/integration-test-templates/job.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.integrationTests.install }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.integrationTests.name }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.integrationTests.name }}-service-account
+      containers:
+        - name: {{ .Values.integrationTests.name }}-container
+          image: {{ .Values.integrationTests.image }}
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/app/check-metric-apiservice.py"]
+      restartPolicy: Never
+  backoffLimit: 0
+  activeDeadlineSeconds: 30
+  ttlSecondsAfterFinished: 900
+{{- end }}

--- a/charts/qubership-prometheus-adapter-operator/values.yaml
+++ b/charts/qubership-prometheus-adapter-operator/values.yaml
@@ -26,7 +26,7 @@ fullnameOverride: ""
 
 # A docker image to use for qubership-prometheus-adapter-operator deployment
 # Type: string
-# Mandatory: true
+# Mandatory: true (if not specified in .values.yaml it will be defined in _helpers.tpl template)
 #
 #image: "ghcr.io/netcracker/qubership-prometheus-adapter-operator:main"
 
@@ -390,3 +390,21 @@ prometheusAdapter:
   # PriorityClassName assigned to the Pods to prevent them from evicting.
   # Type: string
   # priorityClassName: "priorityClassName"
+
+integrationTests:
+  ## A name of a microservice to deploy with.
+  # This name will be used as name of the microservice deployment and in labels.
+  name: prometheus-adapter-tests
+
+  # Allow to enable or disable deploy integration tests.
+  # Type: boolean
+  # Mandatory: no
+  # Default: false
+  #
+  install: false
+
+  # A docker image to use for integration-test deployment
+  # Type: string
+  # Mandatory: false
+  #
+  #image: "integration-test:latest"

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /app
+
+COPY python-scripts/check-metric-apiservice.py .
+CMD ["python", "check-metric-apiservice.py"]

--- a/integration-tests/python-scripts/check-metric-apiservice.py
+++ b/integration-tests/python-scripts/check-metric-apiservice.py
@@ -1,0 +1,40 @@
+# Copyright 2025 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kubernetes import client, config
+
+config.load_incluster_config() #download config inside of cluster
+
+apiservice_client = client.ApiregistrationV1Api()
+api_service_name = 'v1beta1.custom.metrics.k8s.io'
+apiservice = apiservice_client.read_api_service(api_service_name)
+
+available_condition = None
+for condition in apiservice.status.conditions:
+    if condition.type == 'Available':
+        available_condition = condition
+        break
+
+if available_condition:
+    print(
+        f"API Service: {api_service_name}, Status: {available_condition.status}, "
+        f"Message: {available_condition.message}, Reason: {available_condition.reason}"
+    )
+    if available_condition.status == 'False':
+        exit(1)
+    else:
+        exit(0)
+else:
+    print(f"No availability condition found for API Service: {api_service_name}")
+    exit(1)

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes

--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -39,6 +39,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
+// function for run API tests
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
@@ -48,6 +49,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
+	// init test environment with path to CRD
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "charts", "qubership-prometheus-adapter-operator", "crds")},
 	}
@@ -55,13 +57,12 @@ var _ = BeforeSuite(func() {
 	defer GinkgoRecover()
 
 	var err error
+	// start test environment and get it configuration
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	Expect(cfg).ToNot(BeNil())
 
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
+    // add scheme v1alpha1 for Kubernetes scheme
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -39,7 +39,6 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-// function for run API tests
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
@@ -49,7 +48,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
-	// init test environment with path to CRD
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "charts", "qubership-prometheus-adapter-operator", "crds")},
 	}
@@ -57,12 +55,10 @@ var _ = BeforeSuite(func() {
 	defer GinkgoRecover()
 
 	var err error
-	// start test environment and get it configuration
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	Expect(cfg).ToNot(BeNil())
 
-    // add scheme v1alpha1 for Kubernetes scheme
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Helm kubernetes Job was added for integration tests in post-install hook mode.
Job try to search for a new apiservice named v1beta1.custom.metrics.k8s.io after installing the prometheus operator adapter. The job is launched via helm values.yaml
Job requirements:
* Instant self-cleaning in case of successful execution
* In case of a crash, deletion after 15 minutes in order to be able to read the crash logs.

Ginkgo tests for operability were checked. Duplicated code was fixed.