### PR TITLE
Fix nil pointer error when TLS is disabled

### DIFF
--- a/api/v1alpha1/prometheusadapter_types.go
+++ b/api/v1alpha1/prometheusadapter_types.go
@@ -81,7 +81,7 @@ type PrometheusAdapterSpec struct {
 	// More info: https://kubernetes.io/docs/user-guide/annotations
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
-chec
+
 	// Affinity is a group of affinity scheduling rules.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
 	// +optional

--- a/api/v1alpha1/prometheusadapter_types.go
+++ b/api/v1alpha1/prometheusadapter_types.go
@@ -58,6 +58,8 @@ type PrometheusAdapterSpec struct {
 	// SecurityContext holds pod-level security attributes.
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 
+	TLSEnabled bool `json:"tlsEnabled,omitempty"`
+
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
 
 	Auth *Auth `json:"auth,omitempty"`
@@ -79,7 +81,7 @@ type PrometheusAdapterSpec struct {
 	// More info: https://kubernetes.io/docs/user-guide/annotations
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
-
+chec
 	// Affinity is a group of affinity scheduling rules.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
 	// +optional

--- a/charts/qubership-prometheus-adapter-operator/templates/prometheusadapter.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/prometheusadapter.yaml
@@ -35,11 +35,11 @@ spec:
   enableCustomMetrics: {{ .Values.prometheusAdapter.enableCustomMetrics }}
   {{- if .Values.prometheusAdapter.securityContext }}
   securityContext:
-    {{ .Values.prometheusAdapter.securityContext }}
+    {{- toYaml .Values.prometheusAdapter.securityContext | nindent 4 }}
   {{- end }}
   {{- if .Values.prometheusAdapter.resources }}
   resources:
-    {{ .Values.prometheusAdapter.resources }}
+    {{- toYaml .Values.prometheusAdapter.resources | nindent 4 }}
   {{- end }}
   {{- if .Values.prometheusAdapter.labels }}
   labels:
@@ -64,6 +64,7 @@ spec:
   {{- if .Values.prometheusAdapter.priorityClassName }}
   priorityClassName: {{ .Values.prometheusAdapter.priorityClassName | quote }}
   {{- end }}
+  tlsEnabled: {{ .Values.prometheusAdapter.tlsEnabled | default false }}
   {{- if .Values.prometheusAdapter.tlsEnabled }}
   {{- if and .Values.prometheusAdapter.tlsConfig.caSecret .Values.prometheusAdapter.tlsConfig.keySecret .Values.prometheusAdapter.tlsConfig.certSecret }}
   tlsConfig:
@@ -71,7 +72,7 @@ spec:
     certSecret: {{- toYaml .Values.prometheusAdapter.tlsConfig.certSecret | nindent 6 }}
     keySecret: {{- toYaml .Values.prometheusAdapter.tlsConfig.keySecret | nindent 6 }}
   {{- else }}
-  {{-  if .Values.prometheusAdapter.tlsConfig.existingSecret }}
+  {{- if .Values.prometheusAdapter.tlsConfig.existingSecret }}
   tlsConfig:
     caSecret: 
       key: "ca.crt"

--- a/charts/qubership-prometheus-adapter-operator/templates/role.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/role.yaml
@@ -77,3 +77,12 @@ rules:
       - clusterrolebindings
     verbs:
       - create
+
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update

--- a/controllers/manifests.go
+++ b/controllers/manifests.go
@@ -134,7 +134,7 @@ func (f *Factory) PrometheusAdapterDeployment() (*appsv1.Deployment, error) {
 				c.Args = append(c.Args, "--prometheus-url="+f.prometheusAdapterCr.Spec.PrometheusURL)
 			}
 			c.Args = append(c.Args, "--metrics-relist-interval="+f.prometheusAdapterCr.Spec.MetricsRelistInterval)
-			if f.prometheusAdapterCr.Spec.TLSConfig != nil {
+			if f.prometheusAdapterCr.Spec.TLSEnabled && f.prometheusAdapterCr.Spec.TLSConfig != nil {
 				caVolume := corev1.Volume{
 					Name: f.prometheusAdapterCr.Spec.TLSConfig.CA.Name,
 					VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Problem:
When TLS is disabled, the custom resource has `tlsConfig: {}` which is considered as not nil and we have logic to process TLS configurations, which fails.

Solution:
Use `tlsEnabled` flag to process TLS configurations.