### PR TITLE
chore(ci): update golang-ci linter config

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,2 +1,3 @@
+version: "2"
 run:
   timeout: 10m


### PR DESCRIPTION
# What does this PR do?

Update the golangci-linter config for migration from 1.x to 2.x version:
* https://golangci-lint.run/product/migration-guide/
* https://golangci-lint.run/usage/configuration/