### PR TITLE
chore: add pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,11 +49,6 @@ repos:
         args:
           - --config-file
           - .github/linters/.yaml-lint.yml
-  - repo: https://github.com/tekwizely/pre-commit-golang # GoLang Checks
-    rev: e654b74da062c54e9574572365ba5af8a861d04b
-    hooks:
-      - id: go-vulncheck-repo-mod
-      - id: golangci-lint-repo-mod
   - repo: https://github.com/exadmin/CyberFerret # CyberFerret Check
     rev: v.1.2.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit
+repos:
+  # Use latest versions of pre-commit checks
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.9.0
+    hooks:
+      - id: pre-commit-update
+  # General checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: no-commit-to-branch
+      - id: destroyed-symlinks
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  # Conventional commits https://www.conventionalcommits.org
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
+        args:
+          - --strict
+          - --verbose
+  # Check for security leaks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks-docker
+  # YAML checks
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.21.0
+    hooks:
+      - id: yamlfmt
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args:
+          - --config-file
+          - .github/linters/.yaml-lint.yml
+  # CyberFerret Check
+  - repo: https://github.com/exadmin/CyberFerret
+    rev: v.1.2.5
+    hooks:
+      - id: cyberferret

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
   - repo: https://github.com/tekwizely/pre-commit-golang # GoLang Checks
     rev: e654b74da062c54e9574572365ba5af8a861d04b
     hooks:
-      - id: go-mod-tidy-repo
       - id: go-vulncheck-repo-mod
       - id: golangci-lint-repo-mod
   - repo: https://github.com/exadmin/CyberFerret # CyberFerret Check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,14 @@ default_install_hook_types:
 default_stages:
   - pre-commit
 repos:
-  # Use latest versions of pre-commit checks
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update # Use latest versions of pre-commit checks
     rev: v0.9.0
     hooks:
       - id: pre-commit-update
-  # General checks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+        args:
+          - --bleeding-edge
+          - pre-commit-golang
+  - repo: https://github.com/pre-commit/pre-commit-hooks # General checks
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
@@ -23,8 +24,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  # Conventional commits https://www.conventionalcommits.org
-  - repo: https://github.com/compilerla/conventional-pre-commit
+  - repo: https://github.com/compilerla/conventional-pre-commit # Conventional commits https://www.conventionalcommits.org
     rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
@@ -33,25 +33,29 @@ repos:
         args:
           - --strict
           - --verbose
-  # Check for security leaks
-  - repo: https://github.com/gitleaks/gitleaks
+  - repo: https://github.com/gitleaks/gitleaks # Check for security leaks
     rev: v8.30.1
     hooks:
       - id: gitleaks-docker
-  # YAML checks
-  - repo: https://github.com/google/yamlfmt
+  - repo: https://github.com/google/yamlfmt # Restore format of .pre-commit-config.yaml after pre-commit-update
     rev: v0.21.0
     hooks:
       - id: yamlfmt
-  - repo: https://github.com/adrienverge/yamllint
+        files: '^.pre-commit-config.yaml$'
+  - repo: https://github.com/adrienverge/yamllint # YAML checks
     rev: v1.38.0
     hooks:
       - id: yamllint
         args:
           - --config-file
           - .github/linters/.yaml-lint.yml
-  # CyberFerret Check
-  - repo: https://github.com/exadmin/CyberFerret
+  - repo: https://github.com/tekwizely/pre-commit-golang # GoLang Checks
+    rev: e654b74da062c54e9574572365ba5af8a861d04b
+    hooks:
+      - id: go-mod-tidy-repo
+      - id: go-vulncheck-repo-mod
+      - id: golangci-lint-repo-mod
+  - repo: https://github.com/exadmin/CyberFerret # CyberFerret Check
     rev: v.1.2.5
     hooks:
       - id: cyberferret

--- a/.qubership/grand-report.json
+++ b/.qubership/grand-report.json
@@ -1,3 +1,6 @@
 {
-
+  "exclusions" : [ {
+    "t-hash" : "faaad3f13aecde17ebef5037a22df772aeb290147f851d1c9bdf1022009c4d66",
+    "f-hash" : "2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261"
+  } ]
 }


### PR DESCRIPTION
Add support of pre-commit framework's checks.
To use: install https://pre-commit.com/ first.
```
pip install pre-commit
pre-commit install
```
Additional requirements for cyberferret check: Java installed.