### PR TITLE
test: add APIService smoke test

### DIFF
--- a/.github/workflows/helm-apiservice-smoke-test.yaml
+++ b/.github/workflows/helm-apiservice-smoke-test.yaml
@@ -1,0 +1,200 @@
+name: Helm APIService Smoke Test
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "CODE-OF-CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
+      - "SECURITY.md"
+  pull_request:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "CODE-OF-CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "README.md"
+      - "SECURITY.md"
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  helm-test:
+    name: Helm test in kind
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install kind
+        env:
+          KIND_VERSION: v0.27.0
+        run: |
+          curl --proto '=https' --proto-redir '=https' -fsSLo /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+
+      - name: Create kind cluster
+        run: kind create cluster --name apiservice-smoke --image kindest/node:v1.32.0
+
+      - name: Build and load images
+        run: |
+          docker build -t qubership-prometheus-adapter-operator:e2e -f Dockerfile .
+          docker build -t qubership-prometheus-adapter:e2e -f prometheus-adapter/Dockerfile prometheus-adapter
+          docker pull alpine/k8s:1.32.0
+          docker pull python:3.12-alpine
+          kind load docker-image --name apiservice-smoke qubership-prometheus-adapter-operator:e2e
+          kind load docker-image --name apiservice-smoke qubership-prometheus-adapter:e2e
+          kind load docker-image --name apiservice-smoke alpine/k8s:1.32.0
+          kind load docker-image --name apiservice-smoke python:3.12-alpine
+
+      - name: Install fake Prometheus endpoint
+        run: |
+          kubectl create namespace monitoring
+          cat >/tmp/fake-prometheus-openssl.cnf <<'EOF'
+          [req]
+          distinguished_name = req_distinguished_name
+          prompt = no
+          x509_extensions = v3_req
+
+          [req_distinguished_name]
+          CN = prometheus-operated.monitoring.svc
+
+          [v3_req]
+          subjectAltName = @alt_names
+
+          [alt_names]
+          DNS.1 = prometheus-operated
+          DNS.2 = prometheus-operated.monitoring
+          DNS.3 = prometheus-operated.monitoring.svc
+          DNS.4 = prometheus-operated.monitoring.svc.cluster.local
+          EOF
+          openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+            -keyout /tmp/tls.key \
+            -out /tmp/tls.crt \
+            -config /tmp/fake-prometheus-openssl.cnf \
+            -sha256
+          kubectl -n monitoring create secret generic prometheus-adapter-client-tls-secret \
+            --from-file=ca.crt=/tmp/tls.crt \
+            --from-file=tls.crt=/tmp/tls.crt \
+            --from-file=tls.key=/tmp/tls.key
+          cat >/tmp/fake-prometheus.py <<'PY'
+          from http.server import BaseHTTPRequestHandler, HTTPServer
+          import json
+          import ssl
+
+          class Handler(BaseHTTPRequestHandler):
+              def do_GET(self):
+                  self.send_response(200)
+                  self.send_header("Content-Type", "application/json")
+                  self.end_headers()
+                  self.wfile.write(json.dumps({"status": "success", "data": []}).encode())
+
+              def log_message(self, format, *args):
+                  return
+
+          server = HTTPServer(("0.0.0.0", 9090), Handler)
+          context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+          context.load_cert_chain(
+              "/opt/fake-prometheus/tls/tls.crt",
+              "/opt/fake-prometheus/tls/tls.key",
+          )
+          server.socket = context.wrap_socket(server.socket, server_side=True)
+          server.serve_forever()
+          PY
+          kubectl -n monitoring create configmap fake-prometheus --from-file=server.py=/tmp/fake-prometheus.py
+          kubectl -n monitoring apply -f - <<'YAML'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: prometheus-operated
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: prometheus-operated
+            template:
+              metadata:
+                labels:
+                  app: prometheus-operated
+              spec:
+                containers:
+                  - name: prometheus
+                    image: python:3.12-alpine
+                    imagePullPolicy: IfNotPresent
+                    command:
+                      - python
+                      - /opt/fake-prometheus/server.py
+                    ports:
+                      - containerPort: 9090
+                    volumeMounts:
+                      - name: fake-prometheus
+                        mountPath: /opt/fake-prometheus
+                        readOnly: true
+                      - name: fake-prometheus-tls
+                        mountPath: /opt/fake-prometheus/tls
+                        readOnly: true
+                volumes:
+                  - name: fake-prometheus
+                    configMap:
+                      name: fake-prometheus
+                  - name: fake-prometheus-tls
+                    secret:
+                      secretName: prometheus-adapter-client-tls-secret
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: prometheus-operated
+          spec:
+            selector:
+              app: prometheus-operated
+            ports:
+              - port: 9090
+                targetPort: 9090
+          YAML
+          kubectl -n monitoring rollout status deployment/prometheus-operated --timeout=2m
+
+      - name: Install chart
+        run: |
+          helm install prometheus-adapter charts/qubership-prometheus-adapter-operator \
+            --namespace monitoring \
+            --set image=qubership-prometheus-adapter-operator:e2e \
+            --set prometheusAdapter.image=qubership-prometheus-adapter:e2e \
+            --set prometheusAdapter.enableCustomMetrics=true \
+            --set prometheusAdapter.enableResourceMetrics=true \
+            --set prometheusAdapter.prometheusUrl=https://prometheus-operated.monitoring.svc:9090 \
+            --set prometheusAdapter.tlsEnabled=true \
+            --set prometheusAdapter.tlsConfig.existingSecret=prometheus-adapter-client-tls-secret \
+            --set apiServiceSmokeTest.install=true \
+            --wait \
+            --timeout 5m
+
+      - name: Run Helm APIService smoke test
+        run: helm test prometheus-adapter --namespace monitoring --timeout 5m
+
+      - name: Dump diagnostics
+        if: ${{ failure() }}
+        run: |
+          kubectl -n monitoring get all
+          kubectl get apiservices v1beta1.custom.metrics.k8s.io v1beta1.metrics.k8s.io -o yaml
+          kubectl -n monitoring logs deploy/qubership-prometheus-adapter-operator --tail=200 || true
+          kubectl -n monitoring logs deploy/prometheus-adapter --tail=200 || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: mixed-line-ending
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: '^charts/.*/templates/.*\.yaml$'
       - id: check-added-large-files
   - repo: https://github.com/compilerla/conventional-pre-commit # Conventional commits https://www.conventionalcommits.org
     rev: v4.4.0

--- a/charts/qubership-prometheus-adapter-operator/templates/apiservice-smoke-test.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/apiservice-smoke-test.yaml
@@ -138,7 +138,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: 240
+  activeDeadlineSeconds: {{ .Values.apiServiceSmokeTest.activeDeadlineSeconds }}
   ttlSecondsAfterFinished: 900
   template:
     metadata:

--- a/charts/qubership-prometheus-adapter-operator/templates/apiservice-smoke-test.yaml
+++ b/charts/qubership-prometheus-adapter-operator/templates/apiservice-smoke-test.yaml
@@ -1,0 +1,174 @@
+# Copyright 2026 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.apiServiceSmokeTest.install }}
+{{- $fullname := include "qubership-prometheus-adapter-operator.fullname" . }}
+{{- $testName := printf "%s-apiservice-smoke-test" $fullname | trunc 63 | trimSuffix "-" }}
+{{- $apiServices := list }}
+{{- $rawPaths := list }}
+{{- if and .Values.prometheusAdapter.enableCustomMetrics .Values.APIService .Values.APIService.customMetrics }}
+  {{- $apiServices = append $apiServices "v1beta1.custom.metrics.k8s.io" }}
+  {{- $rawPaths = append $rawPaths "/apis/custom.metrics.k8s.io/v1beta1" }}
+{{- end }}
+{{- if and .Values.prometheusAdapter.enableResourceMetrics .Values.APIService .Values.APIService.resourceMetrics }}
+  {{- $apiServices = append $apiServices "v1beta1.metrics.k8s.io" }}
+  {{- $rawPaths = append $rawPaths "/apis/metrics.k8s.io/v1beta1" }}
+{{- end }}
+{{- range .Values.apiServiceSmokeTest.extraAPIServices }}
+  {{- $apiServices = append $apiServices . }}
+{{- end }}
+{{- range .Values.apiServiceSmokeTest.extraRawPaths }}
+  {{- $rawPaths = append $rawPaths . }}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $testName }}
+  labels:
+    name: {{ $testName }}
+    app.kubernetes.io/name: {{ $testName }}
+    app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    {{- include "qubership-prometheus-adapter-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-4"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $testName }}
+  labels:
+    name: {{ $testName }}
+    app.kubernetes.io/name: {{ $testName }}
+    app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    {{- include "qubership-prometheus-adapter-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $testName }}
+  labels:
+    name: {{ $testName }}
+    app.kubernetes.io/name: {{ $testName }}
+    app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    {{- include "qubership-prometheus-adapter-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ $testName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $testName }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $testName }}
+  labels:
+    name: {{ $testName }}
+    app.kubernetes.io/name: {{ $testName }}
+    app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    {{- include "qubership-prometheus-adapter-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  smoke-test.sh: |
+    #!/bin/sh
+    set -eu
+
+    if [ -z "${API_SERVICES}" ] && [ -z "${RAW_PATHS}" ]; then
+      echo "No APIService checks are enabled for this release."
+      exit 0
+    fi
+
+    for api_service in ${API_SERVICES}; do
+      echo "Waiting for APIService ${api_service} to become Available ..."
+      kubectl wait --for=condition=Available --timeout="${WAIT_TIMEOUT}" "apiservice/${api_service}"
+    done
+
+    for raw_path in ${RAW_PATHS}; do
+      echo "Checking aggregated API discovery endpoint ${raw_path} ..."
+      kubectl get --raw "${raw_path}" >/dev/null
+    done
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $testName }}
+  labels:
+    name: {{ $testName }}
+    app.kubernetes.io/name: {{ $testName }}
+    app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    {{- include "qubership-prometheus-adapter-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 240
+  ttlSecondsAfterFinished: 900
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ $testName }}
+        app.kubernetes.io/instance: {{ cat $testName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $testName }}
+      containers:
+        - name: apiservice-smoke-test
+          image: {{ .Values.apiServiceSmokeTest.image }}
+          imagePullPolicy: {{ .Values.apiServiceSmokeTest.imagePullPolicy }}
+          command:
+            - /bin/sh
+            - /opt/smoke-test/smoke-test.sh
+          env:
+            - name: API_SERVICES
+              value: {{ join " " $apiServices | quote }}
+            - name: RAW_PATHS
+              value: {{ join " " $rawPaths | quote }}
+            - name: WAIT_TIMEOUT
+              value: {{ .Values.apiServiceSmokeTest.waitTimeout | quote }}
+          volumeMounts:
+            - name: smoke-test
+              mountPath: /opt/smoke-test
+              readOnly: true
+      volumes:
+        - name: smoke-test
+          configMap:
+            name: {{ $testName }}
+            defaultMode: 0555
+{{- end }}

--- a/charts/qubership-prometheus-adapter-operator/values.yaml
+++ b/charts/qubership-prometheus-adapter-operator/values.yaml
@@ -116,6 +116,12 @@ apiServiceSmokeTest:
   #
   waitTimeout: "180s"
 
+  # Overall timeout for the Helm test Job.
+  # Type: integer
+  # Mandatory: no
+  #
+  activeDeadlineSeconds: 420
+
   # Optional extra APIService names to validate.
   # Type: list[string]
   # Mandatory: no

--- a/charts/qubership-prometheus-adapter-operator/values.yaml
+++ b/charts/qubership-prometheus-adapter-operator/values.yaml
@@ -91,6 +91,43 @@ APIService:
   resourceMetrics: true
   customMetrics: true
 
+apiServiceSmokeTest:
+  # Enable Helm test resources that validate aggregated APIService availability.
+  # Type: boolean
+  # Mandatory: no
+  #
+  install: false
+
+  # A kubectl image used by the Helm test Job.
+  # Type: string
+  # Mandatory: no
+  #
+  image: "alpine/k8s:1.32.0"
+
+  # Image pull policy for the Helm test Job.
+  # Type: string
+  # Mandatory: no
+  #
+  imagePullPolicy: IfNotPresent
+
+  # Timeout used by kubectl wait for each APIService.
+  # Type: string
+  # Mandatory: no
+  #
+  waitTimeout: "180s"
+
+  # Optional extra APIService names to validate.
+  # Type: list[string]
+  # Mandatory: no
+  #
+  extraAPIServices: []
+
+  # Optional extra raw Kubernetes API paths to validate.
+  # Type: list[string]
+  # Mandatory: no
+  #
+  extraRawPaths: []
+
 # Config for resourceMetrics will be added in prometheus-adapter-resource-rules ConfigMap
 #
 # Example:


### PR DESCRIPTION
## Summary
- add optional Helm test resources for aggregated APIService smoke checks
- validate both custom.metrics.k8s.io and metrics.k8s.io discovery endpoints when enabled
- add PR/push workflow that runs the chart in kind and executes helm test

## Checks
- helm lint charts/qubership-prometheus-adapter-operator --set prometheusAdapter.enableResourceMetrics=true --set apiServiceSmokeTest.install=true
- helm template with both APIService checks enabled
- workflow YAML parsed with python3/yaml
- pre-commit hooks during commit

Note: local full kind e2e was started but stopped after kindest/node:v1.32.0 image pull made no progress for several minutes in this environment. The GitHub workflow is intended to run the full kind-based check on PRs.