### PR TITLE
fix(adapter): build prometheus adapter from source

### DIFF
--- a/prometheus-adapter/Dockerfile
+++ b/prometheus-adapter/Dockerfile
@@ -13,12 +13,36 @@
 # limitations under the License.
 
 # hadolint global ignore=DL3018
-FROM registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0 AS source
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG PROMETHEUS_ADAPTER_VERSION=v0.12.0
+
+WORKDIR /workspace
+
+RUN apk add --no-cache \
+        git \
+    && git clone --depth 1 --branch "${PROMETHEUS_ADAPTER_VERSION}" \
+        https://github.com/kubernetes-sigs/prometheus-adapter.git .
+
+RUN go get \
+        go.opentelemetry.io/otel@v1.43.0 \
+        go.opentelemetry.io/otel/metric@v1.43.0 \
+        go.opentelemetry.io/otel/sdk@v1.43.0 \
+        go.opentelemetry.io/otel/trace@v1.43.0 \
+        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/net@v0.55.0 \
+        golang.org/x/oauth2@v0.34.0 \
+        google.golang.org/grpc@v1.79.3
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
+    go build -trimpath -o /adapter sigs.k8s.io/prometheus-adapter/cmd/adapter
 
 FROM alpine:3.24.1
 
 WORKDIR /
-COPY --from=source /adapter ./
+COPY --from=builder /adapter ./
 COPY entrypoint.sh ./
 
 ENV USER_UID=1001 \

--- a/prometheus-adapter/Dockerfile
+++ b/prometheus-adapter/Dockerfile
@@ -26,18 +26,19 @@ RUN apk add --no-cache \
     && git clone --depth 1 --branch "${PROMETHEUS_ADAPTER_VERSION}" \
         https://github.com/kubernetes-sigs/prometheus-adapter.git .
 
-RUN go get \
-        go.opentelemetry.io/otel@v1.43.0 \
-        go.opentelemetry.io/otel/metric@v1.43.0 \
-        go.opentelemetry.io/otel/sdk@v1.43.0 \
-        go.opentelemetry.io/otel/trace@v1.43.0 \
-        golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
-        golang.org/x/oauth2@v0.34.0 \
-        google.golang.org/grpc@v1.79.3
+RUN go mod edit \
+        -require=go.opentelemetry.io/otel@v1.43.0 \
+        -require=go.opentelemetry.io/otel/metric@v1.43.0 \
+        -require=go.opentelemetry.io/otel/sdk@v1.43.0 \
+        -require=go.opentelemetry.io/otel/trace@v1.43.0 \
+        -require=golang.org/x/crypto@v0.52.0 \
+        -require=golang.org/x/net@v0.55.0 \
+        -require=golang.org/x/oauth2@v0.34.0 \
+        -require=google.golang.org/grpc@v1.79.3 \
+    && go mod tidy
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
-    go build -trimpath -o /adapter sigs.k8s.io/prometheus-adapter/cmd/adapter
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" GO111MODULE=on \
+    go build -mod=readonly -trimpath -o /adapter sigs.k8s.io/prometheus-adapter/cmd/adapter
 
 FROM alpine:3.24.1
 


### PR DESCRIPTION
**Why**

The `qubership-prometheus-adapter` image copied the `adapter` binary from the upstream `registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0` image. That upstream image is built with an older Go toolchain and older transitive dependencies.

**What**

- Build `prometheus-adapter` from the upstream `v0.12.0` source tag in this image build.
- Use the Go `1.26.4` builder image.
- Refresh selected transitive Go dependencies before compiling the `adapter` binary.
- Keep the existing Alpine runtime image and entrypoint behavior.

**How to verify**

- `docker build --pull --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -t codex/qubership-prometheus-adapter:patched -f prometheus-adapter/Dockerfile prometheus-adapter`